### PR TITLE
Changed Markov.Markov() to Markov() as it errors

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -8,7 +8,7 @@ def end(s):
     else:
         return False
 
-m = Markov.Markov(prob=True, level=2)
+m = Markov(prob=True, level=2)
 with open("text-test") as file:
     m.parse(file.read())
     print m.generate(endf=end)


### PR DESCRIPTION
Appears that maybe the example was not in sync with the current package as Markov.Markov throws an AttributeError. Example in readme also shows this as Markov() rather than Markov.Markov().
